### PR TITLE
Add ADR and LlamaIndex hybrid RAG v2 design with QueryExpansionRetrieverV2 proposal

### DIFF
--- a/docs/adr/ADR-0002-additive-rag-v2-path.md
+++ b/docs/adr/ADR-0002-additive-rag-v2-path.md
@@ -1,0 +1,15 @@
+# ADR-0002: Additive LlamaIndex RAG v2 Namespace
+
+**Status:** Proposed
+**Date:** 2025-02-14
+
+## Context
+The catalog codebase already provides v1 search and ingestion flows built on LlamaIndex. We need to integrate a new hybrid RAG option derived from a separate design without disrupting existing clients or storage.
+
+## Decision
+Introduce a new, explicit `catalog.search_v2` namespace for the additive hybrid RAG path. The v2 path will reuse existing storage, embedding, and retrieval seams while remaining opt-in. The existing `catalog.search` API will remain unchanged.
+
+## Consequences
+- Existing clients are unaffected unless they opt into v2.
+- v2 development can proceed without refactoring v1 components.
+- Parallel paths require ongoing parity testing and configuration management.

--- a/docs/features/llamaindex-hybrid-rag-v2.md
+++ b/docs/features/llamaindex-hybrid-rag-v2.md
@@ -1,0 +1,150 @@
+# LlamaIndex Hybrid RAG v2 (Additive) Integration Design
+
+## Summary
+This document proposes an additive LlamaIndex-based RAG + hybrid retrieval path for the catalog codebase. The design keeps existing search and ingestion flows intact while introducing an opt-in v2 path that reuses current storage, embedding, and retrieval seams.
+
+## Existing Seams & Contracts
+
+### A) Storage & Vector I/O
+- Vector persistence and retrieval is managed via `catalog.store.vector.VectorStoreManager`, which creates/loads a `VectorStoreIndex` and persists to the configured `IDX_VECTOR_STORE_PATH` directory.
+- Vector queries are executed either directly against `SimpleVectorStore` (`catalog.search.vector.VectorSearch`) or via `VectorStoreIndex.as_retriever()` in the hybrid path (`catalog.search.hybrid.HybridSearch`).
+- Dataset scoping relies on `source_doc_id = "{dataset}:{path}"` in node metadata. The hybrid retriever uses LlamaIndex `MetadataFilters` with `FilterOperator.CONTAINS` on `source_doc_id`, while direct vector search filters results in Python.
+
+### B) Embeddings Access
+- Embedding model creation is centralized in `catalog.embedding.get_embed_model()` and `catalog.store.vector.VectorStoreManager._get_embed_model()`.
+- MLX and HuggingFace embeddings are supported, with batch size defined by `IDX_EMBEDDING__BATCH_SIZE`.
+- No explicit embedding cache or retry middleware exists; models are lazily initialized.
+
+### C) Document/Node Persistence
+- Documents are persisted via `catalog.transform.llama.PersistenceTransform`, which writes to SQLite and updates `documents_fts`.
+- Chunk nodes are persisted via `catalog.transform.llama.ChunkPersistenceTransform`, which sets stable node IDs (`{content_hash}:{chunk_seq}`) and writes to `chunks_fts` with `source_doc_id` metadata.
+
+### D) Retrieval Pipeline Assembly
+- `catalog.search.fts_chunk.FTSChunkRetriever` implements a LlamaIndex `BaseRetriever` over the `chunks_fts` FTS5 index.
+- `catalog.search.hybrid.HybridSearch` assembles a `QueryFusionRetriever` (RRF mode) over FTS and vector retrievers.
+- `catalog.search.rerank.Reranker` wraps LlamaIndex `LLMRerank` postprocessing.
+
+### E) External Function API Layer
+- The public `catalog.search.search()` function returns `SearchResults` and sets up sessions.
+- `catalog.search.service.SearchService` is the primary orchestrator and uses `SearchCriteria` and `SearchResult` Pydantic models.
+
+### F) Ingestion Pipeline Assembly
+- `catalog.ingest.pipelines.DatasetIngestPipeline` orchestrates ingestion using a LlamaIndex `IngestionPipeline`, with persistence and chunking transforms (`PersistenceTransform`, `ChunkPersistenceTransform`, and `SentenceSplitter`).
+- Dataset-level metadata normalization and source-specific transforms are attached via `catalog.ingest.sources.create_source()` and its transform hooks.
+- FTS and chunk FTS tables are ensured during ingestion through `catalog.store.fts.create_fts_table()` and `catalog.store.fts_chunk.create_chunks_fts_table()`.
+
+## Parallel Path Strategy
+
+### Exposure Strategy
+Introduce a new, explicit namespace:
+- `catalog.search_v2.search()` convenience function
+- `catalog.search_v2.service.SearchServiceV2` orchestrator
+
+Default behavior stays unchanged; v2 is opt-in by using the new namespace.
+
+### Compatibility & Migration
+- Clients can adopt `catalog.search_v2` without changing existing `catalog.search` flows.
+- Provide a side-by-side comparison mode in v2 (`compare_with_v1=True`) for internal evaluation.
+- Rollback is achieved by reverting to `catalog.search.search()`.
+
+## Design-to-Repo Mapping Table
+
+| Capability | LlamaIndex abstraction | Existing seam | Proposed new code | Config knobs | Parity risks |
+| --- | --- | --- | --- | --- | --- |
+| Chunking defaults + overlap | `SentenceSplitter` / `TokenTextSplitter` | `catalog.ingest.pipelines.DatasetIngestPipeline` | `catalog/search_v2/ingestion.py` | `IDX_RAG_V2__CHUNK_SIZE`, `IDX_RAG_V2__CHUNK_OVERLAP` | Token vs char chunk parity |
+| Embedding text formatting | `TransformComponent` | `catalog.transform.llama` pipeline | `catalog/search_v2/transforms.py` | `IDX_RAG_V2__EMBED_PREFIX_QUERY`, `IDX_RAG_V2__EMBED_PREFIX_DOC` | Prefix mismatch risk |
+| Ingestion pipeline assembly | `IngestionPipeline` | `DatasetIngestPipeline` + transforms | `catalog/search_v2/ingestion.py` | `IDX_RAG_V2__INGEST__*` | Pipeline ordering parity |
+| Vector retrieval | `VectorIndexRetriever` | `VectorStoreManager` | `catalog/search_v2/retrievers.py` | `IDX_RAG_V2__VECTOR_TOP_K` | Score normalization |
+| Lexical retrieval | `BaseRetriever` | `FTSChunkRetriever` | reuse existing retriever | `IDX_RAG_V2__FTS_TOP_K` | FTS scoring differences |
+| Hybrid fusion | `QueryFusionRetriever` | `HybridSearch` | `HybridRetrieverFactoryV2` | `IDX_RAG_V2__FUSION_TOP_K` | RRF weighting parity |
+| Reranking | `LLMRerank` | `Reranker` | `catalog/search_v2/rerank.py` | `IDX_RAG_V2__RERANK_TOP_N` | Model parity |
+| Snippet/citation shaping | response glue | `SearchResult` fields | `catalog/search_v2/formatting.py` | snippet length | No chunk snippet helper |
+| Evaluation harness | Pytest | existing tests | `tests/rag_v2/` | thresholds | dataset variability |
+
+## Proposed New Mid-Layer Abstractions
+
+### EmbeddingPrefixTransform
+- **Purpose:** Apply QMD-style prefixes to embeddings while reusing the existing embedding infrastructure.
+- **Location:** `src/catalog/catalog/search_v2/transforms.py`
+- **Interface:** `__call__(nodes: list[BaseNode]) -> list[BaseNode]`
+- **Dependencies:** `catalog.embedding.get_embed_model`, existing ingestion pipeline.
+- **Rationale:** LlamaIndex does not provide prefix formatting by default.
+
+### HybridRetrieverFactoryV2
+- **Purpose:** Centralize construction of a `QueryFusionRetriever` using existing FTS and vector retrievers.
+- **Location:** `src/catalog/catalog/search_v2/retrievers.py`
+- **Interface:** `build(query, dataset_name, k_lex, k_dense, k_fused) -> QueryFusionRetriever`
+- **Dependencies:** `FTSChunkRetriever`, `VectorStoreManager`.
+- **Rationale:** Keeps RRF configuration versioned and isolated from v1.
+
+### QueryEngineBuilderV2
+- **Purpose:** Assemble retriever + postprocessors + response shaping for v2.
+- **Location:** `src/catalog/catalog/search_v2/engine.py`
+- **Interface:** `build_query_engine(...) -> RetrieverQueryEngine`
+- **Dependencies:** `Reranker` and LlamaIndex query engine components.
+- **Rationale:** Encapsulates wiring and enables opt-in features (rerank, fusion).
+
+### IngestionPipelineBuilderV2
+- **Purpose:** Compose a v2 ingestion pipeline that reuses existing persistence and chunking transforms while enabling v2-specific embedding formatting.
+- **Location:** `src/catalog/catalog/search_v2/ingestion.py`
+- **Interface:** `build_pipeline(dataset_id, dataset_name, embed_model, chunk_size, chunk_overlap) -> IngestionPipeline`
+- **Dependencies:** `PersistenceTransform`, `ChunkPersistenceTransform`, `SentenceSplitter`, `VectorStoreManager`, source transforms from `catalog.ingest.sources`.
+- **Rationale:** Keeps v2 ingestion separate while honoring current storage and FTS contracts.
+
+## Phased Implementation Plan
+
+### Phase 1: Minimal vertical slice (parallel path)
+- **Scope:** Hybrid retrieval using existing FTS + vector seams, plus a v2 ingestion builder that wires existing persistence transforms.
+- **Code locations:**
+  - `src/catalog/catalog/search_v2/__init__.py`
+  - `src/catalog/catalog/search_v2/service.py`
+  - `src/catalog/catalog/search_v2/retrievers.py`
+  - `src/catalog/catalog/search_v2/ingestion.py`
+- **Tests:** `tests/rag_v2/test_hybrid_retrieval.py`
+- **Done means:** `search_v2` returns `SearchResults` with `SearchResult` payloads matching v1 schema, and `IngestionPipelineBuilderV2` builds a pipeline that reuses existing persistence transforms.
+
+### Phase 2: Quality parity
+- **Scope:** Prefix formatting + reranking.
+- **Code locations:**
+  - `src/catalog/catalog/search_v2/transforms.py`
+  - `src/catalog/catalog/search_v2/rerank.py`
+- **Tests:** `tests/rag_v2/test_rerank.py`
+- **Done means:** Reranked results align with expected ordering and v1-compatible output shape.
+
+### Phase 3: Operationalization
+- **Scope:** Config, metrics, and performance knobs.
+- **Code locations:**
+  - `src/catalog/catalog/core/settings.py`
+  - `src/catalog/catalog/search_v2/service.py`
+- **Tests:** `tests/rag_v2/test_settings.py`
+- **Done means:** v2 behavior is driven by `IDX_RAG_V2__*` configuration.
+
+### Phase 4: Evaluation & rollout
+- **Scope:** Golden queries and side-by-side evaluation mode.
+- **Code locations:**
+  - `tests/rag_v2/test_eval.py`
+  - `src/catalog/catalog/search_v2/service.py`
+- **Done means:** `compare_with_v1=True` supports evaluation without replacing v1.
+
+## Change Boundaries
+- Do not change `catalog.search.service.SearchService`, `catalog.search.search()`, or existing v1 retrievers.
+- All v2 additions should live under `catalog/search_v2/` and new tests under `tests/rag_v2/`.
+- Only extend `catalog.core.settings.Settings` to add v2 configuration keys.
+
+## Rollout & Evaluation Plan
+- New v2 namespace is opt-in by default.
+- Side-by-side comparison mode for internal regression testing.
+- Golden-query evaluation ensures hit@k parity for hybrid retrieval.
+
+## Risks & Mitigations
+- **Chunking parity risk:** Provide optional token-based splitter config and keep defaults aligned with existing usage.
+- **Embedding prefix mismatch:** Encode prefixes in a minimal `TransformComponent`.
+- **Score comparability:** Focus on ranking parity rather than score parity.
+
+## Additional Gaps vs Original Artifact
+- **Query expansion + HyDE:** The current retrieval path uses `QueryFusionRetriever` with `num_queries=1` and no query expansion, and there is no query pipeline or transform wired into search yet. For v2, implement a LlamaIndex-based `QueryExpansionRetrieverV2` in `catalog/search_v2/retrievers.py` that composes: (1) a `QueryTransform` (e.g., LlamaIndex `HyDEQueryTransform` for HyDE) plus a lightweight custom `LexVecQueryTransform` that emits separate query lists for lexical vs vector retrieval, and (2) a `QueryFusionRetriever` configured with `num_queries` equal to the total expansion count. The retriever should: build expanded query bundles per retriever, preserve the original query with higher weight (by duplicating the original query in the expansion list or using LlamaIndex retriever weights), and pass dataset filters through unchanged. This keeps expansion logic within LlamaIndex abstractions (query transforms + fusion retriever) while aligning to current `HybridSearch`-style assembly and avoiding custom RRF logic. 
+- **Rerank caching:** `catalog.search.rerank.Reranker` wraps `LLMRerank` directly with no caching layer. If parity requires caching, the v2 design should introduce a cache adapter around rerank calls, but the current codebase has no cache seam dedicated to rerank results. This implies the v2 plan needs to specify a cache store or reuse an existing cache utility if one exists. 
+- **Snippet extraction / citation formatting:** Current search results return `chunk_text`, `chunk_seq`, and `chunk_pos` in `SearchResult`, but there is no snippet extraction helper in the Python catalog path; only FTS snippet utilities exist at the document level. The v2 design should decide whether to reuse `chunks_fts` text directly, add a snippet helper that uses chunk offsets, or extend the response shaping layer to mirror TS-style line-anchored snippets. 
+- **Vector store join behavior / per-doc dedupe:** `VectorSearch` returns chunk-level results by querying `SimpleVectorStore` and then looking up chunk text in SQLite, with dataset filtering done in Python and no per-document dedupe logic beyond `top_k` truncation. If parity requires per-document best-chunk dedupe, add a postprocessing step in the v2 pipeline or use a LlamaIndex postprocessor to collapse nodes per `source_doc_id`. 
+- **Docstore strategy + cache use:** The ingestion pipeline currently uses `SimpleDocumentStore` and persists pipeline state via `catalog.ingest.cache.load_pipeline` and `persist_pipeline`, but the v2 plan does not specify how docstore caching integrates with new v2 ingestion or how pipeline cache is reused across runs. V2 ingestion should explicitly reuse these cache helpers or define a replacement strategy consistent with existing ingestion semantics. 
+- **Evaluation parity:** Existing tests exercise hybrid behavior with LlamaIndex fusion and reranking, but there is no golden-query Hit@K suite configured for BM25/vector/hybrid parity. A v2 evaluation plan should define datasets, metric thresholds, and test locations that align with `catalog/tests/idx` integration tests and any new `tests/rag_v2` suite. 


### PR DESCRIPTION
### Motivation
- Record an opt-in additive v2 path for hybrid RAG that can evolve independently of the existing v1 flows by adding an ADR and detailed design artifacts. 
- Provide a concrete, repo-aligned design for LlamaIndex-based query expansion (HyDE) and hybrid retriever assembly to close identified v2 parity gaps. 

### Description
- Added an ADR at `docs/adr/ADR-0002-additive-rag-v2-path.md` that formalizes the opt-in `catalog.search_v2` namespace and its intended consequences. 
- Added `docs/features/llamaindex-hybrid-rag-v2.md` with a full design doc that maps new v2 abstractions to repo locations, a phased rollout plan, and parity/risk analysis. 
- Expanded the query-expansion section to propose a LlamaIndex-based `QueryExpansionRetrieverV2` (to live at `catalog/search_v2/retrievers.py`) that composes a `QueryTransform` (e.g., `HyDEQueryTransform` + a lightweight `LexVecQueryTransform`) with a `QueryFusionRetriever`, preserves original query weighting, and passes dataset filters through unchanged. 
- Enumerated other v2 gaps and recommendations including rerank caching, snippet extraction, per-document dedupe, docstore/cache strategy, and evaluation harness locations (`tests/rag_v2/`).

### Testing
- No automated tests were run because the changes are documentation-only. 
- The change set is limited to `docs/adr/ADR-0002-additive-rag-v2-path.md` and `docs/features/llamaindex-hybrid-rag-v2.md` and does not modify runtime code paths or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698219a384188325903262efa624f00e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that introduces no runtime behavior modifications; risk is limited to potential confusion if the proposed v2 namespace/design diverges from future implementation.
> 
> **Overview**
> Adds an ADR proposing an opt-in, additive `catalog.search_v2` namespace for a new LlamaIndex hybrid RAG v2 path while explicitly keeping `catalog.search` unchanged.
> 
> Adds a detailed design doc describing the planned v2 ingestion/retrieval abstractions, configuration knobs, phased rollout/testing plan, and a proposal for LlamaIndex-based query expansion (`QueryExpansionRetrieverV2`/HyDE) plus identified parity gaps (rerank caching, snippet shaping, per-doc dedupe, cache strategy, evaluation harness).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b8af8b84caeee6d80f7dc9e3a47e511d1806413. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->