### PR TITLE
feat(catalog): implement reproducible search eval harness workflow

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,3 +74,19 @@ Interactive TUI for loading dataset fixtures into the database.
 ```bash
 uv run scripts/load-datasets.py
 ```
+
+### Search Evaluation
+
+#### `run_search_eval.py`
+Runs an isolated ingestion + golden-query eval and writes a run record JSON
+artifact for longitudinal comparison.
+
+**Usage:**
+```bash
+uv run python scripts/run_search_eval.py \
+  --corpus src/catalog/tests/corpus/vault-small \
+  --queries-file src/catalog/tests/rag_v2/fixtures/golden_queries.json
+```
+
+**Outputs (default):**
+- `reports/evals/<YYYY-MM-DD>/<timestamp>.json` - run record with metrics + metadata

--- a/scripts/run_search_eval.py
+++ b/scripts/run_search_eval.py
@@ -1,0 +1,163 @@
+"""Run a reproducible search eval and emit a run record JSON artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from catalog.eval.harness import (
+    baseline_key,
+    build_run_record,
+    prepare_eval_environment,
+    read_eval_metrics,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for eval harness execution."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, required=True, help="Path to fixed eval corpus")
+    parser.add_argument(
+        "--queries-file",
+        type=Path,
+        required=True,
+        help="Path to golden queries JSON",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("reports/evals"),
+        help="Directory where run record artifacts are written",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        default="eval-vault",
+        help="Dataset name used during ingestion",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default="mlx-community/all-MiniLM-L6-v2-bf16",
+        help="Embedding model identifier for eval run",
+    )
+    parser.add_argument(
+        "--catalog-db-path",
+        type=Path,
+        default=Path("/tmp/catalog-eval/catalog.db"),
+        help="Isolated catalog DB path",
+    )
+    parser.add_argument(
+        "--content-db-path",
+        type=Path,
+        default=Path("/tmp/catalog-eval/content.db"),
+        help="Isolated content DB path",
+    )
+    parser.add_argument(
+        "--vector-store-path",
+        type=Path,
+        default=Path("/tmp/catalog-eval/vectors"),
+        help="Isolated vector store path",
+    )
+    parser.add_argument(
+        "--baseline-dir",
+        type=Path,
+        default=Path("reports/evals/baselines"),
+        help="Directory containing baseline run records",
+    )
+    parser.add_argument(
+        "--compare-baseline",
+        action="store_true",
+        help="Fail if no baseline exists for current config",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root for git metadata collection",
+    )
+    return parser.parse_args()
+
+
+def run() -> int:
+    """Execute ingest + eval flow and persist run record artifact."""
+
+    args = parse_args()
+    env = prepare_eval_environment(
+        catalog_db_path=args.catalog_db_path,
+        content_db_path=args.content_db_path,
+        vector_store_path=args.vector_store_path,
+        embedding_model=args.embedding_model,
+    )
+
+    args.catalog_db_path.parent.mkdir(parents=True, exist_ok=True)
+    args.content_db_path.parent.mkdir(parents=True, exist_ok=True)
+    args.vector_store_path.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/ingest_obsidian_vault.py",
+            str(args.corpus),
+            "--dataset-name",
+            args.dataset_name,
+        ],
+        env=env,
+        check=True,
+    )
+
+    eval_run = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "catalog",
+            "eval",
+            "golden",
+            "--queries-file",
+            str(args.queries_file),
+            "--output",
+            "json",
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    metrics = read_eval_metrics(eval_run.stdout)
+    run_time = datetime.now(timezone.utc)
+    run_record = build_run_record(
+        corpus_path=args.corpus,
+        queries_file=args.queries_file,
+        embedding_model=args.embedding_model,
+        metrics=metrics,
+        run_time=run_time,
+        repo_root=args.repo_root,
+    )
+
+    day_dir = args.output_dir / run_time.strftime("%Y-%m-%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    output_path = day_dir / f"{run_time.strftime('%Y-%m-%dT%H-%M-%SZ')}.json"
+    output_path.write_text(json.dumps(run_record, indent=2))
+
+    baseline_id = baseline_key(run_record)
+    baseline_path = args.baseline_dir / f"{baseline_id}.json"
+
+    if args.compare_baseline and not baseline_path.exists():
+        raise FileNotFoundError(
+            f"Baseline not found for current config. Expected: {baseline_path}"
+        )
+
+    print(f"Run record written: {output_path}")
+    print(f"Baseline key: {baseline_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/src/catalog/catalog/eval/harness.py
+++ b/src/catalog/catalog/eval/harness.py
@@ -1,0 +1,209 @@
+"""Search evaluation harness utilities.
+
+This module orchestrates reproducible golden-query evaluation runs and
+normalizes run metadata into a JSON-serializable record format.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agentlayer.logging import get_logger
+
+from catalog.core.settings import get_settings
+
+logger = get_logger(__name__)
+
+DEFAULT_FTS_IMPL = "sqlite_fts5"
+
+
+@dataclass
+class GitMetadata:
+    """Minimal git metadata for an eval run record."""
+
+    commit: str
+    branch: str
+    dirty: bool
+
+
+def compute_corpus_hash(corpus_path: Path) -> str:
+    """Compute a stable sha256 hash for a corpus directory.
+
+    The hash includes relative file paths and file bytes for all files in the
+    corpus tree. Paths are sorted to ensure deterministic output.
+    """
+
+    if not corpus_path.exists():
+        raise FileNotFoundError(f"Corpus path does not exist: {corpus_path}")
+
+    if corpus_path.is_file():
+        files = [corpus_path]
+        root = corpus_path.parent
+    else:
+        files = sorted(path for path in corpus_path.rglob("*") if path.is_file())
+        root = corpus_path
+
+    digest = hashlib.sha256()
+    for file_path in files:
+        relative_path = file_path.relative_to(root).as_posix()
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def read_queries_version(queries_file: Path) -> str:
+    """Read golden query version from JSON.
+
+    Returns ``"unversioned"`` when no explicit ``version`` key is present.
+    """
+
+    payload = json.loads(queries_file.read_text())
+    if isinstance(payload, dict):
+        version = payload.get("version")
+        if isinstance(version, str) and version.strip():
+            return version
+    return "unversioned"
+
+
+def read_eval_metrics(stdout: str) -> dict[str, Any]:
+    """Parse evaluation metrics JSON emitted by ``catalog eval golden``.
+
+    The eval CLI may print informational lines before the JSON payload. This
+    parser extracts the last JSON object from stdout.
+    """
+
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    for start in range(len(lines)):
+        candidate = "\n".join(lines[start:])
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            return data
+        raise ValueError("Expected eval JSON object")
+
+    raise ValueError("Unable to parse eval JSON output")
+
+
+def collect_git_metadata(repo_root: Path) -> GitMetadata:
+    """Collect commit, branch, and dirty state for the run record."""
+
+    commit = _run_git(repo_root, ["rev-parse", "HEAD"])
+    branch = _run_git(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    dirty_exit = subprocess.run(
+        ["git", "diff", "--quiet"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    ).returncode
+    return GitMetadata(commit=commit, branch=branch, dirty=(dirty_exit != 0))
+
+
+def build_run_record(
+    *,
+    corpus_path: Path,
+    queries_file: Path,
+    embedding_model: str,
+    metrics: dict[str, Any],
+    fts_impl: str = DEFAULT_FTS_IMPL,
+    run_time: datetime | None = None,
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Build a canonical run record envelope for search evals."""
+
+    now = run_time or datetime.now(timezone.utc)
+    settings = get_settings()
+    git_meta = collect_git_metadata(repo_root)
+
+    rag_v2 = settings.rag_v2
+    run_record = {
+        "run_id": now.isoformat(),
+        "git": asdict(git_meta),
+        "corpus": {
+            "path": str(corpus_path.resolve()),
+            "hash": compute_corpus_hash(corpus_path),
+        },
+        "queries": {
+            "path": str(queries_file.resolve()),
+            "version": read_queries_version(queries_file),
+        },
+        "settings": {
+            "embedding_model": embedding_model,
+            "fts_impl": fts_impl,
+            "rag_v2": {
+                "chunk_size": rag_v2.chunk_size,
+                "chunk_overlap": rag_v2.chunk_overlap,
+                "rrf_k": rag_v2.rrf_k,
+                "rerank_enabled": rag_v2.rerank_enabled,
+                "expansion_enabled": rag_v2.expansion_enabled,
+            },
+        },
+        "metrics": metrics,
+    }
+    return run_record
+
+
+def baseline_key(run_record: dict[str, Any]) -> str:
+    """Build deterministic baseline key from run metadata."""
+
+    settings = run_record["settings"]
+    rag_v2 = settings["rag_v2"]
+    return "__".join(
+        [
+            run_record["corpus"]["hash"],
+            run_record["queries"]["version"],
+            settings["embedding_model"],
+            settings["fts_impl"],
+            f"chunk_size={rag_v2['chunk_size']}",
+            f"chunk_overlap={rag_v2['chunk_overlap']}",
+            f"rrf_k={rag_v2['rrf_k']}",
+            f"rerank={int(rag_v2['rerank_enabled'])}",
+            f"expand={int(rag_v2['expansion_enabled'])}",
+        ]
+    )
+
+
+def prepare_eval_environment(
+    *,
+    catalog_db_path: Path,
+    content_db_path: Path,
+    vector_store_path: Path,
+    embedding_model: str,
+) -> dict[str, str]:
+    """Prepare environment variables for isolated eval execution."""
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "IDX_DATABASES_CATALOG_PATH": str(catalog_db_path),
+            "IDX_DATABASES_CONTENT_PATH": str(content_db_path),
+            "IDX_VECTOR_STORE_PATH": str(vector_store_path),
+            "IDX_EMBEDDING_MODEL": embedding_model,
+        }
+    )
+    return env
+
+
+def _run_git(repo_root: Path, args: list[str]) -> str:
+    """Run a git command and return stdout stripped."""
+
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()

--- a/src/catalog/features/search-eval-harness-implementation.md
+++ b/src/catalog/features/search-eval-harness-implementation.md
@@ -1,0 +1,51 @@
+# Search Eval Harness Implementation
+
+This feature adds a concrete harness command for longitudinal search-quality
+tracking using the existing golden-query evaluation CLI.
+
+## What was implemented
+
+- `scripts/run_search_eval.py`
+  - Orchestrates isolated ingestion + golden-query evaluation.
+  - Captures a run record JSON with git metadata, corpus hash, query version,
+    selected retrieval settings, and evaluation metrics.
+  - Supports baseline-key generation and optional baseline presence checks.
+- `catalog.eval.harness`
+  - Reusable utilities for run record generation and metadata normalization.
+  - Stable corpus hashing for baseline partitioning.
+  - Parsing helper for eval CLI output.
+- `tests/rag_v2/test_eval_harness.py`
+  - Unit coverage for corpus hashing, version extraction, metrics parsing,
+    run record structure, and baseline-key determinism.
+
+## Usage
+
+From repository root:
+
+```bash
+uv run python scripts/run_search_eval.py \
+  --corpus src/catalog/tests/corpus/vault-small \
+  --queries-file src/catalog/tests/rag_v2/fixtures/golden_queries.json \
+  --output-dir reports/evals \
+  --dataset-name eval-vault \
+  --embedding-model mlx-community/all-MiniLM-L6-v2-bf16
+```
+
+### Optional baseline gate
+
+```bash
+uv run python scripts/run_search_eval.py \
+  --corpus src/catalog/tests/corpus/vault-small \
+  --queries-file src/catalog/tests/rag_v2/fixtures/golden_queries.json \
+  --compare-baseline
+```
+
+When `--compare-baseline` is enabled, the command fails if the baseline file
+for the current baseline key is not present under `reports/evals/baselines/`.
+
+## Notes
+
+- Harness execution is intentionally isolated from developer-local databases via
+  explicit IDX path overrides.
+- This implementation performs baseline existence checks only; score-threshold
+  diffing can be added in a follow-up increment.

--- a/src/catalog/tests/rag_v2/test_eval_harness.py
+++ b/src/catalog/tests/rag_v2/test_eval_harness.py
@@ -1,0 +1,115 @@
+"""Tests for search eval harness utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import sys
+import types
+
+agentlayer_module = types.ModuleType("agentlayer")
+logging_module = types.ModuleType("agentlayer.logging")
+logging_module.get_logger = lambda _name: None
+agentlayer_module.logging = logging_module
+sys.modules.setdefault("agentlayer", agentlayer_module)
+sys.modules.setdefault("agentlayer.logging", logging_module)
+
+from catalog.eval import harness
+
+
+class _RagV2Settings:
+    def __init__(self) -> None:
+        self.chunk_size = 800
+        self.chunk_overlap = 120
+        self.rrf_k = 60
+        self.rerank_enabled = True
+        self.expansion_enabled = True
+
+
+class _Settings:
+    def __init__(self) -> None:
+        self.rag_v2 = _RagV2Settings()
+
+
+def test_compute_corpus_hash_stable_for_same_content(tmp_path: Path) -> None:
+    """Corpus hash remains stable for deterministic corpus content."""
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "note1.md").write_text("alpha")
+    (corpus / "nested").mkdir()
+    (corpus / "nested" / "note2.md").write_text("beta")
+
+    first_hash = harness.compute_corpus_hash(corpus)
+    second_hash = harness.compute_corpus_hash(corpus)
+
+    assert first_hash == second_hash
+
+
+def test_read_queries_version_returns_declared_version(tmp_path: Path) -> None:
+    """Version metadata is read when golden query file provides one."""
+    queries_file = tmp_path / "queries.json"
+    queries_file.write_text(json.dumps({"version": "2.1", "queries": []}))
+
+    assert harness.read_queries_version(queries_file) == "2.1"
+
+
+def test_read_eval_metrics_parses_json_after_preface() -> None:
+    """Eval metrics parser handles human-readable preface output."""
+    payload = "Loaded 3 queries\n{\"hybrid\": {\"easy\": {\"hit_at_1\": 1.0}}}"
+
+    assert harness.read_eval_metrics(payload) == {"hybrid": {"easy": {"hit_at_1": 1.0}}}
+
+
+def test_build_run_record_includes_expected_sections(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Run record captures metadata, settings, and metrics envelope."""
+    corpus = tmp_path / "vault"
+    corpus.mkdir()
+    (corpus / "doc.md").write_text("content")
+
+    queries_file = tmp_path / "queries.json"
+    queries_file.write_text(json.dumps({"version": "1.0", "queries": []}))
+
+    monkeypatch.setattr(harness, "collect_git_metadata", lambda _: harness.GitMetadata("abc", "branch", False))
+    monkeypatch.setattr(harness, "get_settings", lambda: _Settings())
+
+    run_record = harness.build_run_record(
+        corpus_path=corpus,
+        queries_file=queries_file,
+        embedding_model="test-model",
+        metrics={"hybrid": {"easy": {"hit_at_1": 1.0}}},
+        run_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        repo_root=tmp_path,
+    )
+
+    assert run_record["run_id"] == "2026-01-01T00:00:00+00:00"
+    assert run_record["git"]["commit"] == "abc"
+    assert run_record["queries"]["version"] == "1.0"
+    assert run_record["settings"]["embedding_model"] == "test-model"
+    assert run_record["metrics"]["hybrid"]["easy"]["hit_at_1"] == 1.0
+
+
+def test_baseline_key_is_deterministic() -> None:
+    """Baseline key remains stable for identical metadata content."""
+    run_record = {
+        "corpus": {"hash": "sha256:abc"},
+        "queries": {"version": "1.0"},
+        "settings": {
+            "embedding_model": "model",
+            "fts_impl": "sqlite_fts5",
+            "rag_v2": {
+                "chunk_size": 800,
+                "chunk_overlap": 120,
+                "rrf_k": 60,
+                "rerank_enabled": True,
+                "expansion_enabled": True,
+            },
+        },
+    }
+
+    assert harness.baseline_key(run_record) == harness.baseline_key(run_record)


### PR DESCRIPTION
### Motivation
- Provide a repeatable, versioned evaluation workflow for tracking search quality regressions over time (FTS / vector / hybrid).  
- Capture stable metadata (corpus hash, golden query version, git commit, RAG settings) so runs can be grouped and compared to baselines.  
- Offer a non-invasive orchestration layer that reuses existing ingest and golden-eval logic while isolating eval execution from developer data.

### Description
- Add `scripts/run_search_eval.py`, a CLI wrapper that ingests a pinned corpus into isolated DB/vector paths, runs `catalog eval golden`, and writes a timestamped run-record JSON artifact.  
- Add `src/catalog/catalog/eval/harness.py` providing utilities for stable corpus hashing, golden-query version extraction, robust eval-output JSON parsing, git metadata collection, canonical run-record construction, baseline-key generation, and environment preparation.  
- Add unit tests `src/catalog/tests/rag_v2/test_eval_harness.py` covering corpus hashing, query-version reading, eval JSON parsing, run-record composition, and baseline-key determinism.  
- Document the implementation and usage in `src/catalog/features/search-eval-harness-implementation.md` and extend `scripts/README.md` with `run_search_eval.py` usage notes.

### Testing
- Ran unit tests for the harness: `uv run pytest tests/rag_v2/test_eval_harness.py -v` and all tests passed (5 passed).  
- Verified the harness CLI help: `uv run python scripts/run_search_eval.py --help` succeeded and printed usage.  
- Attempted differential suite driver `make agent-test TESTPATH=tests/rag_v2` but it failed in this environment due to the configured pytest `--testmon` option not being available (environment issue, not harness code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987da002cb483259e67cd67c5caf000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily additive, but it shells out to ingestion/eval CLIs and reads/writes isolated DB/vector paths and git state, which can be environment-sensitive and affect CI/dev workflows if misconfigured.
> 
> **Overview**
> Adds a new reproducible *search evaluation harness* that orchestrates isolated ingestion and `catalog eval golden`, then persists a timestamped JSON run record for longitudinal comparison.
> 
> Introduces `catalog.eval.harness` utilities to standardize run metadata (git commit/branch/dirty state, corpus sha256 hash, golden-query version, selected RAG v2 settings) and to generate deterministic baseline keys plus robust parsing of eval JSON output.
> 
> Includes unit tests for corpus hashing/version parsing/run-record structure/baseline-key determinism, and documents usage in `scripts/README.md` and `search-eval-harness-implementation.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be11c9d60589f77e3a0bb3f848e032ce13195e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->